### PR TITLE
Put Tailwind base CSS in a single file and then reference it from individual style files to avoid duplication

### DIFF
--- a/bin/build.styles.js
+++ b/bin/build.styles.js
@@ -1,9 +1,9 @@
 const glob = require("glob");
 const path = require('path');
 
-const { sourceCss, config} = require("./config");
+const { sourceCss, srcDir, config} = require("./config");
 
-const buildCss = require("./build.css.js");
+const { buildCss, buildTailwindBaseCss } = require("./build.css.js");
 
 module.exports = (logger) => {
   const styleFiles = glob.sync(sourceCss.replace(/\\/g, "/"));
@@ -13,7 +13,8 @@ module.exports = (logger) => {
   if (!styleFiles.length) {
     throw new Error(sourceCss, "why you no provide files?");
   }
+  buildTailwindBaseCss(srcDir, config, logger);
   styleFiles.forEach((filePath) => {
-    buildCss(filePath, config, logger);
+    buildCss(filePath, srcDir, config, logger);
   });
 };


### PR DESCRIPTION
Right now, all of the generated `.style.ts` files contain a copy of the base Tailwind CSS. This PR makes it so that we put the base Tailwind CSS in one file instead, and then reference that file from all of the generated `.style.ts` files.

In my case, this saves around 150KB of duplicated CSS in my final JS bundle.

The easiest way to see what is happening is to compare the generated `.style.ts` files in a project that uses `sirocco-wc` before and after this change.